### PR TITLE
Bugfix/issue10 no restrictions on special character

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template, request, redirect, url_for, flash, jso
 from models import db, Contact
 from forms import ContactForm
 import os
+import re  
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'your-secret-key')
@@ -29,12 +30,29 @@ def list_contacts():
 def add_contact():
     form = ContactForm()
     if form.validate_on_submit():
-        contact = Contact(
-            name=form.name.data,
-            phone=form.phone.data,
-            email=form.email.data,
-            type=form.type.data
-        )
+        name = form.name.data
+        phone = form.phone.data
+        email = form.email.data
+
+        # Regex Patterns
+        name_pattern = r'^[A-Za-z\s]+$'  # Only letters and spaces allowed
+        phone_pattern = r'^\d{10,15}$'   # Only digits, 10-15 characters
+        email_pattern = r'^[\w\.-]+@[\w\.-]+\.\w+$'  # Standard email format
+        
+        # Validate Inputs
+        if not re.match(name_pattern, name):
+            flash('Invalid name! Only letters and spaces are allowed.', 'danger')
+            return render_template('add_contact.html', form=form)
+
+        if not re.match(phone_pattern, phone):
+            flash('Invalid phone number! Only digits (10-15) are allowed.', 'danger')
+            return render_template('add_contact.html', form=form)
+
+        if not re.match(email_pattern, email):
+            flash('Invalid email format!', 'danger')
+            return render_template('add_contact.html', form=form)
+
+        contact = Contact(name=name, phone=phone, email=email, type=form.type.data)
         try:
             db.session.add(contact)
             db.session.commit()

--- a/app.py
+++ b/app.py
@@ -56,6 +56,7 @@ def update_contact(id):
         contact.email = form.email.data
         contact.type = form.type.data         #Fix: Ensure 'type' is updated
         db.session.commit()
+        flash('Contact updated successfully!', 'success')  # ✅ Added flash message
         return redirect(url_for('list_contacts'))
     
     return render_template('update_contact.html', form=form, contact=contact)

--- a/app.py
+++ b/app.py
@@ -54,6 +54,7 @@ def update_contact(id):
         contact.name = form.name.data
         contact.phone = form.phone.data
         contact.email = form.email.data
+        contact.type = form.type.data         #Fix: Ensure 'type' is updated
         db.session.commit()
         return redirect(url_for('list_contacts'))
     

--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -39,16 +39,6 @@
                {% endfor %}
             {% endif %}
         {% endwith %}
-        {% with messages = get_flashed_messages(with_categories=true) %}
-            {% if messages %}
-                {% for category, message in messages %}
-                   <div class="alert alert-{{ category }}">
-                    {{ message }}
-                   </div>
-                {% endfor %}
-            {% endif %}
-        {% endwith %}
-
     </tbody>
 </table>
 

--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -39,6 +39,16 @@
                {% endfor %}
             {% endif %}
         {% endwith %}
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                {% for category, message in messages %}
+                   <div class="alert alert-{{ category }}">
+                    {{ message }}
+                   </div>
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+
     </tbody>
 </table>
 

--- a/templates/contacts.html
+++ b/templates/contacts.html
@@ -30,6 +30,15 @@
             </td>
         </tr>
         {% endfor %}
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+               {% for category, message in messages %}
+                    <div class="alert alert-{{ category }}">
+                       {{ message }}
+                    </div>
+               {% endfor %}
+            {% endif %}
+        {% endwith %}
     </tbody>
 </table>
 


### PR DESCRIPTION
Since I changed the code to limit the use of special characters in each type—such as name, phone number, and email type—this problem has been fixed. Thus, the user will now receive restriction notifications anytime he fills out a form by adding special characters to his name and alphabets to phone number.

![nam](https://github.com/user-attachments/assets/1c8c332c-577a-4fd3-a9c9-df0a85b03c6f)

![image](https://github.com/user-attachments/assets/07813034-c307-4dae-ae94-409c07c54909)
